### PR TITLE
Update opencv-python

### DIFF
--- a/AppExamples/misc/DisplayImage/scripts/modules/requirements.txt
+++ b/AppExamples/misc/DisplayImage/scripts/modules/requirements.txt
@@ -1,2 +1,2 @@
-numpy == 1.26.4
+numpy == 2.0.2
 opencv-python == 4.12.0.88

--- a/AppExamples/misc/DisplayImage/scripts/modules/requirements.txt
+++ b/AppExamples/misc/DisplayImage/scripts/modules/requirements.txt
@@ -1,2 +1,2 @@
 numpy == 1.26.4
-opencv-python == 4.10.0.84
+opencv-python == 4.12.0.88

--- a/AppExamples/misc/TextDetection/scripts/modules/requirements.txt
+++ b/AppExamples/misc/TextDetection/scripts/modules/requirements.txt
@@ -1,3 +1,3 @@
-numpy == 1.26.4
-opencv-python == 4.10.0.84
+numpy == 2.0.2
+opencv-python == 4.12.0.88
 pytesseract == 0.3.13


### PR DESCRIPTION
The new opencv-python version requires numpy-2.0.2